### PR TITLE
Fix user anonymous UI when the current user is the anonymous poster

### DIFF
--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -140,11 +140,20 @@ module.exports = function (Topics) {
 				postObj.votes = postObj.votes || 0;
 				postObj.replies = replies[i];
 				postObj.selfPost = parseInt(uid, 10) > 0 && parseInt(uid, 10) === postObj.uid;
-				// If the current viewer is not the original poster and the post was made anonymous, do not show the user name
-				postObj.user.userslug = postObj.anonymous && (postObj.uid !== uid) ? '' : postObj.user.userslug;
-				postObj.user.displayname = postObj.anonymous && (postObj.uid !== uid) ? 'Anonymous' : postObj.user.displayname;
-				postObj.user.picture = postObj.anonymous && (postObj.uid !== uid) ? null : postObj.user.picture;
-				postObj.user['icon:text'] = postObj.anonymous && (postObj.uid !== uid) ? 'A' : postObj.user['icon:text'];
+	
+				// Check for anonymous posts and modify username accordingly
+				if (postObj.anonymous && postObj.uid === uid) {
+					postObj.user.displayname += ' (anonymous)';
+					postObj.user.userslug = ''; // Clear the userslug for anonymous display
+					postObj.user.picture = null; // Remove the user picture
+					postObj.user['icon:text'] = 'A'; 
+				} else if (postObj.anonymous && postObj.uid !== uid) {
+					postObj.user.displayname = 'Anonymous';
+					postObj.user.userslug = '';
+					postObj.user.picture = null;
+					postObj.user['icon:text'] = 'A';
+				}
+	
 				// Username override for guests, if enabled
 				if (meta.config.allowGuestHandles && postObj.uid === 0 && postObj.handle) {
 					postObj.user.username = validator.escape(String(postObj.handle));

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -140,20 +140,20 @@ module.exports = function (Topics) {
 				postObj.votes = postObj.votes || 0;
 				postObj.replies = replies[i];
 				postObj.selfPost = parseInt(uid, 10) > 0 && parseInt(uid, 10) === postObj.uid;
-	
+
 				// Check for anonymous posts and modify username accordingly
 				if (postObj.anonymous && postObj.uid === uid) {
 					postObj.user.displayname += ' (anonymous)';
 					postObj.user.userslug = ''; // Clear the userslug for anonymous display
 					postObj.user.picture = null; // Remove the user picture
-					postObj.user['icon:text'] = 'A'; 
+					postObj.user['icon:text'] = 'A';
 				} else if (postObj.anonymous && postObj.uid !== uid) {
 					postObj.user.displayname = 'Anonymous';
 					postObj.user.userslug = '';
 					postObj.user.picture = null;
 					postObj.user['icon:text'] = 'A';
 				}
-	
+
 				// Username override for guests, if enabled
 				if (meta.config.allowGuestHandles && postObj.uid === 0 && postObj.handle) {
 					postObj.user.username = validator.escape(String(postObj.handle));


### PR DESCRIPTION
**What:** when the current user is the anonymous poster, the username shows the user their original username, but that it was posted anonymously, eg: "rey (anonymous)". 

**Testing:** Visually see that the user's own posts are marked anonymous as appropriate. When switching between users, the anonymous posts similarly switch between users. 

Resolves #33