### PR TITLE
Add check so that people can’t register with "anonymous" as a username

### DIFF
--- a/public/src/utils.common.js
+++ b/public/src/utils.common.js
@@ -328,7 +328,7 @@ const utils = {
 	},
 
 	isUserNameValid: function (name) {
-		return (name && name !== '' && (/^['" \-+.*[\]0-9\u00BF-\u1FFF\u2C00-\uD7FF\w]+$/.test(name)));
+		return (name && name !== '' && name.toLowerCase() !== 'anonymous' && (/^['" \-+.*[\]0-9\u00BF-\u1FFF\u2C00-\uD7FF\w]+$/.test(name)));
 	},
 
 	isPasswordValid: function (password) {


### PR DESCRIPTION
**What**
User is now unable to register with "anonymous" as a username.

<img width="361" alt="image" src="https://github.com/user-attachments/assets/e858db1c-0d1c-4487-85b9-26fb9d1d9278">

Partially resolves #39.

**How**
Added check in the isUserNameValid method in the `public/src/utils.common.js` file. 