### PR TITLE
Add deanonymize button to frontend and setup backend for future

### DIFF
--- a/public/src/client/topic/change-owner.js
+++ b/public/src/client/topic/change-owner.js
@@ -23,6 +23,7 @@ define('forum/topic/change-owner', [
 			$('body').append(modal);
 
 			modal.find('#change_owner_cancel').on('click', closeModal);
+			modal.find('#deanonymize').on('click', () => deanonymize(postEl.attr('data-uid')));
 			modal.find('#username').on('keyup', checkButtonEnable);
 			postSelect.init(onPostToggled, {
 				allowMainPostSelect: true,
@@ -43,6 +44,11 @@ define('forum/topic/change-owner', [
 			});
 		});
 	};
+
+	async function deanonymize() {
+		// setup functionality in future for deanonymizing a post
+		closeModal();
+	}
 
 	function showPostsSelected() {
 		if (postSelect.pids.length) {

--- a/public/src/client/topic/change-owner.js
+++ b/public/src/client/topic/change-owner.js
@@ -23,6 +23,7 @@ define('forum/topic/change-owner', [
 			$('body').append(modal);
 
 			modal.find('#change_owner_cancel').on('click', closeModal);
+			modal.find('#deanonymize').on('click', () => deanonymize(postEl.attr('data-uid')));
 			modal.find('#username').on('keyup', checkButtonEnable);
 			postSelect.init(onPostToggled, {
 				allowMainPostSelect: true,
@@ -44,6 +45,12 @@ define('forum/topic/change-owner', [
 		});
 	};
 
+	async function deanonymize(uid) {
+		// setup functionality in future for deanonymizing a post
+
+		closeModal()
+	}
+	
 	function showPostsSelected() {
 		if (postSelect.pids.length) {
 			modal.find('#pids').translateHtml('[[topic:fork-pid-count, ' + postSelect.pids.length + ']]');

--- a/src/views/modals/change-owner.tpl
+++ b/src/views/modals/change-owner.tpl
@@ -19,6 +19,7 @@
 	</div>
 	<div class="card-footer text-end">
 		<button class="btn btn-link btn-sm" id="change_owner_cancel">[[global:buttons.close]]</button>
+		<button class="btn btn-link btn-sm" id="deanonymize">Deanonymize</button>
 		<button class="btn btn-primary btn-sm" id="change_owner_commit" disabled>[[topic:change-owner]]</button>
 	</div>
 </div>


### PR DESCRIPTION
### What
Add a deanonymize button and setup click handler

### How
Added button to change-owner.tpl file and added a click handler to the button in change-owner.js. The click handler does nothing except close the modal for now but is setup so that only the actual logic has to be set up since the infrastructure is there

### Testing
Since it is frontend, I just did visual testing

### Issue
resolves #38

### Extra details
I spent a lot of time going through different files to try and get the backend working, but was ultimately unsuccessful. I attempted but failed at:
- Adding a function that calls the change owner function on oneself but adding the anonymous field to the payload
- Calling the edit post api and adding anon to its payload. I was successful here in terms that I could see the field in the backend and it the topic was successfully edited, but it would go away when the page would reload
- Doing a combination of these two approaches

### Future
Continue experimenting with backend approach that works to get backend functionality that successfully deanonymizes a post 

### Screenshot
<img width="737" alt="Screenshot 2024-10-10 at 2 27 12 AM" src="https://github.com/user-attachments/assets/099d7dd9-3a28-4dae-b913-e2bc699489a7">
